### PR TITLE
#37 認可処理機能 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:show, :edit, :update]
   def show
     @user = User.find(params[:id])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
   private
 
     def user_params
-      params.require(:user).permit(:password, :password_confirmation, :last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :email, :phone_number)
+      params.require(:user).permit(:password, :password_confirmation, :last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments,
+                                   :email, :phone_number)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
   before_action :logged_in_user, only: [:show, :edit, :update]
+  before_action :correct_user, only: [:show, :edit, :update]
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -26,7 +26,8 @@ module SessionsHelper
   def correct_user
     user = User.find(params[:id])
     unless user == current_user
-      redirect_to root_path, flash: { danger: "他人の情報にアクセスすることはできません。" }
+      flash[:danger] = "他人の情報にアクセスすることはできません。"
+      redirect_to root_path
     end
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -22,4 +22,10 @@ module SessionsHelper
     redirect_to login_path
     end
   end
+
+  def correct_user
+    @user = User.find(params[:id])
+    flash[:danger] = "他人の情報にアクセスすることはできません。"
+    redirect_to(root_path) unless @user == current_user
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -26,6 +26,7 @@ module SessionsHelper
   def correct_user
     user = User.find(params[:id])
     unless user == current_user
+      #### root_pathに該当する箇所は未実装状態のため、エラーする ####
       flash[:danger] = "他人の情報にアクセスすることはできません。"
       redirect_to root_path
     end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,4 +15,11 @@ module SessionsHelper
   def logged_in?
     current_user.present?
   end
+
+  def logged_in_user
+    unless logged_in?
+    flash[:danger] = "ログインしてください"
+    redirect_to login_path
+    end
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -18,15 +18,15 @@ module SessionsHelper
 
   def logged_in_user
     unless logged_in?
-    flash[:danger] = "ログインしてください"
-    redirect_to login_path
+      flash[:danger] = "ログインしてください"
+      redirect_to login_path
     end
   end
 
   def correct_user
     user = User.find(params[:id])
     unless user == current_user
-      redirect_to root_path, flash: { danger: '他人の情報にアクセスすることはできません。' }
+      redirect_to root_path, flash: { danger: "他人の情報にアクセスすることはできません。" }
     end
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -24,8 +24,9 @@ module SessionsHelper
   end
 
   def correct_user
-    @user = User.find(params[:id])
-    flash[:danger] = "他人の情報にアクセスすることはできません。"
-    redirect_to(root_path) unless @user == current_user
+    user = User.find(params[:id])
+    unless user == current_user
+      redirect_to root_path, flash: { danger: '他人の情報にアクセスすることはできません。' }
+    end
   end
 end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- ログインしていない状態で users/show, users/edit にアクセスしようすると、ログイン画面にリダイレクトするようにした
- ログインしていても、ログインユーザー以外のユーザー情報にアクセスしようとしたら、root_path にリダイレクトするようにした。(現時点でroot_path は未実装のため、エラーする)

## 対象issue
- https://github.com/quest-academia/qa-rails-ec-training-azalea/issues/37

## 重点的に見てほしいところ(不安なところ)
テストのために、一旦、`docker-compose run web rails g controller home index`でroot_path に該当する部分を生成し、テスト後に、`docker-compose run web rails d controller home index`で消す、と言う方法を取ったが、これは適切だったか。

## 実装できなくて後回しにしたところ
なし

## チェックリスト
- [x] 動作確認は実行した?
- [x] rubocopは実行した?

## その他参考情報
- https://railstutorial.jp/chapters/updating_and_deleting_users?version=4.2#sec-requiring_logged_in_users
  - 9.2.1, 9.2.2 の章を参考にした。
