### PR TITLE
#41 ユーザー登録ページ、登録処理

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    @user.user_classification_id = 1
+    @user.user_classification_id = 1 # 今はユーザー種別が購入者となるようデフォルトで設定している
     if @user.save
       flash[:success] = "ユーザーを登録しました。こちらからログインしてください。"
       redirect_to login_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,22 @@ class UsersController < ApplicationController
   before_action :logged_in_user, only: [:show, :edit, :update]
   before_action :correct_user, only: [:show, :edit, :update]
 
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    @user.user_classification_id = 1
+    if @user.save
+      flash[:success] = "ユーザーを登録しました。こちらからログインしてください。"
+      redirect_to login_path
+    else
+      flash.now[:error] = "ユーザー登録に失敗しました。入力内容をもう一度お確かめください。"
+      render "new"
+    end
+  end
+
   def show
     @user = User.find(params[:id])
   end
@@ -25,6 +41,6 @@ class UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:password, :password_confirmation, :last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments,
-                                   :email, :phone_number)
+                                   :company_name, :email, :phone_number)
     end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,15 +3,16 @@
   <div class="d-flex justify-content-center">
     <div class="form-group">
       <%= form_with url: login_path, local: true do |form| %>
-        <%= form.label :email, "メールアドレス" %>
-        <p><%= form.email_field :email %></p>
-        <%= form.label :password, "パスワード" %>
-        <p><%= form.password_field :password %></p>
-        <%= form.submit "ログイン", class: "btn btn-primary", style: "width:100%;" %>
+      <%= form.label :email, "メールアドレス" %>
+      <p><%= form.email_field :email %></p>
+      <%= form.label :password, "パスワード" %>
+      <p><%= form.password_field :password %></p>
+      <%= form.submit "ログイン", class: "btn btn-primary", style: "width:100%;" %>
       <% end %>
     </div>
   </div>
   <div class="d-flex justify-content-center">
-    <a href="">まだ登録がお済みでない方はこちら</a>
+    <%= link_to "まだ登録がお済みでない方はこちら", signup_path %>
+  </div>
   </div>
 </main>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,11 +3,11 @@
   <div class="d-flex justify-content-center">
     <div class="form-group">
       <%= form_with url: login_path, local: true do |form| %>
-      <%= form.label :email, "メールアドレス" %>
-      <p><%= form.email_field :email %></p>
-      <%= form.label :password, "パスワード" %>
-      <p><%= form.password_field :password %></p>
-      <%= form.submit "ログイン", class: "btn btn-primary", style: "width:100%;" %>
+        <%= form.label :email, "メールアドレス" %>
+        <p><%= form.email_field :email %></p>
+        <%= form.label :password, "パスワード" %>
+        <p><%= form.password_field :password %></p>
+        <%= form.submit "ログイン", class: "btn btn-primary", style: "width:100%;" %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,101 +1,101 @@
 <main>
-  <div class="container">
-    <div class="jumbotron text-center bg-white mt-5">
-      <h2>お客様情報登録</h2>
-    </div>
-    <div class="row mb-5 ml-5">
-      <div class="col-sm-6 offset-sm-3">
-        <%= form_for (@user) do |form| %>
-        <div>
-          <p>氏名</p>
-          <div class="row ms-2">
-              <%= form.label :last_name, "姓", class: "col-sm" %>
-            <div class="col-sm-5">
-              <%= form.text_field :last_name, class: "form-control", id: "last_name", maxlength: 10 %>
-            </div>
-              <%= form.label :first_name, "名", class: "col-sm" %>
-            <div class="col-sm-5">
-              <%= form.text_field :first_name, class: "form-control", id: "first_name", maxlength: 10 %>
-            </div>
-          </div>
-          <div>
-            <%= form.label :zipcode, "郵便番号" %>
-            <div class="col-sm-6 ms-4">
-              <%= form.text_field :zipcode, class: "form-control", id: "zipcode", title: "半角数字でハイフンを含めて入力してください", pattern: "[0-9]{3}-[0-9]{4}",length: 8 %>
-            </div>
-          </div>
-          <div>
-            <p class="mb-1">住所</p>
-            <div class="ms-4">
-              <div class="row">
-                <%= form.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
-                <div class="col-sm-9 mt-1">
-                  <%= form.text_field :prefecture, class: "form-control", id: "prefecture", maxlength: 5 %>
-                </div>
-              </div>
+  <%= form_for (@user) do |form| %>
+    <h2 class="text-center mt-5">お客様情報登録</h2>
 
-              <div class="row">
-                <%= form.label :municipality, "市町村区", class: "ml-4 mt-2 col-sm" %>
-                <div class="col-sm-9 mt-1">
-                  <%= form.text_field :municipality, class: "form-control", id: "municipality", maxlength: 10 %>
-                </div>
-              </div>
-              <div class="row">
-                <%= form.label :address, "番地", class: "mt-2 ml-4 mr-2 col-sm" %>
-                <div class="col-sm-9 ml-4 mt-1">
-                  <%= form.text_field :address, class: "form-control", id: "address", maxlength: 15 %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div>
-            <%= form.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
-            <div class="offset-sm-1">
-              <div class="ml-5 mr-5">
-                <%= form.text_field :apartments, class: "form-control", id: "apartments", maxlength: 20 %>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <%= form.label :company_name, "会社名" %>
-          <div class="ml-3 mr-5 ms-4">
-            <%= form.text_field :company_name, class: "form-control", id: "company_name" %>
-          </div>
-        </div>
-          <%= form.label :email, "メールアドレス" %>
-          <div class="ml-3 mr-5 ms-4">
-            <%= form.email_field :email, class: "form-control", id: "email" %>
-          </div>
-        </div>
-        <div>
-          <%= form.label :phone_number, "電話番号" %>
-          <div class="ml-3 mr-5 ms-4">
-            <%= form.text_field :phone_number, class: "form-control", id: "phone_number", title: "半角数字でハイフンを含めずに入力してください", pattern: "[0-9][0-9]*", maxlength: "15" %>
-          </div>
-        </div>
-        <div>
-          <%= form.label :password, "パスワード" %>
-          <div class="col-sm-8 ms-4">
-            <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
-          </div>
-        </div>
-        <div>
-          <%= form.label :password, "パスワード再入力" %>
-          <div class="col-sm-8 ms-4">
-            <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
-          </div>
-        </div>
-        <div class="row justify-content-center">
+    <table width="60%" style="margin: auto;">
+      <tr height="40">
+        <td align="center">氏名</td>
+        <td>
+          <%= form.label :last_name, "姓" %>
+          <%= form.text_field :last_name, id: "last_name", maxlength: 10 %>
+          <%= form.label :first_name, "名" %>
+          <%= form.text_field :first_name, id: "first_name", maxlength: 10 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center">郵便番号</td>
+        <td>
+          <%= form.label :zipcode, "〒" %>
+          <%= form.text_field :zipcode, id: "zipcode", title: "半角数字でハイフンを含めて入力してください", pattern: "[0-9]{3}-[0-9]{4}",length: 8 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :prefecture, "都道府県" %></td>
+        <td>
+          <%= form.text_field :prefecture, style:"width: 100%;", id: "prefecture", maxlength: 5 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :municipality, "市区町村" %></td>
+        <td colspan="2">
+          <%= form.text_field :municipality, style:"width: 100%;", id: "municipality", maxlength: 10 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :address, "番地" %></td>
+        <td>
+          <%= form.text_field :address, style:"width: 100%;", id: "address", maxlength: 15 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :apartments, "マンション部屋番号" %></td>
+        <td>
+          <%= form.text_field :apartments, style:"width: 100%;", id: "apartments", maxlength: 20 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :company_name, "会社名" %></td>
+        <td>
+          <%= form.text_field :company_name, style:"width: 100%;", id: "company_name" %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :email, "メールアドレス" %></td>
+        <td>
+          <%= form.email_field :email, style:"width: 100%;", id: "email" %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :phone_number, "電話番号" %></td>
+        <td>
+          <%= form.text_field :phone_number, style:"width: 100%;", id: "phone_number", 
+              title: "半角数字でハイフンを含めずに入力してください", pattern: "[0-9][0-9]*", maxlength: "15" %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :password, "パスワード" %></td>
+        <td>
+          <%= form.password_field :password, style:"width: 100%;", id: "password", 
+              pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
+        </td>
+      </tr>
+
+      <tr height="40">
+        <td align="center"><%= form.label :password_confirmation, "パスワード (再入力)" %></td>
+        <td>
+          <%= form.password_field :password_confirmation, style:"width: 100%;", id: "password", 
+              pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
+        </td>
+      </tr>
+    </table>
+
+    <div class="row justify-content-center">
           <div class="col-sm-2 mt-5">
             <%= form.submit "登録", class: "btn btn-primary btn-block" %>
           </div>
-        </div>
-        <div class="mt-5 text-center">
-          <h3><%= link_to "ログインはこちらから", login_path %></h3>
-        </div>
-        <% end %>
-      </div>
     </div>
-  </div>
+    <div class="mt-5 text-center">
+      <h3><%= link_to "ログインはこちらから", login_path %></h3>
+    </div>
+    <% end %>
 </main>
+

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -5,90 +5,90 @@
     </div>
     <div class="row mb-5 ml-5">
       <div class="col-sm-6 offset-sm-3">
-      <%= form_for (@user) do |form| %>
+        <%= form_for (@user) do |form| %>
         <div>
           <p>氏名</p>
           <div class="row ms-2">
-            <%= form.label :last_name, "姓", class: "col-sm" %>
+              <%= form.label :last_name, "姓", class: "col-sm" %>
             <div class="col-sm-5">
-            <%= form.text_field :last_name, class: "form-control", id: "last_name", maxlength: 10 %>
+              <%= form.text_field :last_name, class: "form-control", id: "last_name", maxlength: 10 %>
             </div>
-            <%= form.label :first_name, "名", class: "col-sm" %>
+              <%= form.label :first_name, "名", class: "col-sm" %>
             <div class="col-sm-5">
-            <%= form.text_field :first_name, class: "form-control", id: "first_name", maxlength: 10 %>
+              <%= form.text_field :first_name, class: "form-control", id: "first_name", maxlength: 10 %>
             </div>
           </div>
           <div>
-          <%= form.label :zipcode, "郵便番号" %>
+            <%= form.label :zipcode, "郵便番号" %>
             <div class="col-sm-6 ms-4">
-            <%= form.text_field :zipcode, class: "form-control", id: "zipcode", title: "半角数字でハイフンを含めて入力してください", pattern: "[0-9]{3}-[0-9]{4}",length: 8 %>
+              <%= form.text_field :zipcode, class: "form-control", id: "zipcode", title: "半角数字でハイフンを含めて入力してください", pattern: "[0-9]{3}-[0-9]{4}",length: 8 %>
             </div>
           </div>
           <div>
             <p class="mb-1">住所</p>
             <div class="ms-4">
               <div class="row">
-              <%= form.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
+                <%= form.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
                 <div class="col-sm-9 mt-1">
-                <%= form.text_field :prefecture, class: "form-control", id: "prefecture", maxlength: 5 %>
+                  <%= form.text_field :prefecture, class: "form-control", id: "prefecture", maxlength: 5 %>
                 </div>
               </div>
 
               <div class="row">
-              <%= form.label :municipality, "市町村区", class: "ml-4 mt-2 col-sm" %>
+                <%= form.label :municipality, "市町村区", class: "ml-4 mt-2 col-sm" %>
                 <div class="col-sm-9 mt-1">
-                <%= form.text_field :municipality, class: "form-control", id: "municipality", maxlength: 10 %>
+                  <%= form.text_field :municipality, class: "form-control", id: "municipality", maxlength: 10 %>
                 </div>
               </div>
               <div class="row">
-              <%= form.label :address, "番地", class: "mt-2 ml-4 mr-2 col-sm" %>
+                <%= form.label :address, "番地", class: "mt-2 ml-4 mr-2 col-sm" %>
                 <div class="col-sm-9 ml-4 mt-1">
-                <%= form.text_field :address, class: "form-control", id: "address", maxlength: 15 %>
+                  <%= form.text_field :address, class: "form-control", id: "address", maxlength: 15 %>
                 </div>
               </div>
             </div>
           </div>
           <div>
-          <%= form.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
+            <%= form.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
             <div class="offset-sm-1">
               <div class="ml-5 mr-5">
-              <%= form.text_field :apartments, class: "form-control", id: "apartments", maxlength: 20 %>
+                <%= form.text_field :apartments, class: "form-control", id: "apartments", maxlength: 20 %>
               </div>
             </div>
           </div>
         </div>
         <div>
-        <%= form.label :company_name, "会社名" %>
+          <%= form.label :company_name, "会社名" %>
           <div class="ml-3 mr-5 ms-4">
-          <%= form.text_field :company_name, class: "form-control", id: "company_name" %>
+            <%= form.text_field :company_name, class: "form-control", id: "company_name" %>
           </div>
         </div>
-        <%= form.label :email, "メールアドレス" %>
+          <%= form.label :email, "メールアドレス" %>
           <div class="ml-3 mr-5 ms-4">
-          <%= form.email_field :email, class: "form-control", id: "email" %>
-          </div>
-        </div>
-        <div>
-        <%= form.label :phone_number, "電話番号" %>
-          <div class="ml-3 mr-5 ms-4">
-          <%= form.text_field :phone_number, class: "form-control", id: "phone_number", title: "半角数字でハイフンを含めずに入力してください", pattern: "[0-9][0-9]*", maxlength: "15" %>
+            <%= form.email_field :email, class: "form-control", id: "email" %>
           </div>
         </div>
         <div>
-        <%= form.label :password, "パスワード" %>
+          <%= form.label :phone_number, "電話番号" %>
+          <div class="ml-3 mr-5 ms-4">
+            <%= form.text_field :phone_number, class: "form-control", id: "phone_number", title: "半角数字でハイフンを含めずに入力してください", pattern: "[0-9][0-9]*", maxlength: "15" %>
+          </div>
+        </div>
+        <div>
+          <%= form.label :password, "パスワード" %>
           <div class="col-sm-8 ms-4">
-          <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
+            <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
           </div>
         </div>
         <div>
           <%= form.label :password, "パスワード再入力" %>
           <div class="col-sm-8 ms-4">
-          <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
+            <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
           </div>
         </div>
         <div class="row justify-content-center">
           <div class="col-sm-2 mt-5">
-          <%= form.submit "登録", class: "btn btn-primary btn-block" %>
+            <%= form.submit "登録", class: "btn btn-primary btn-block" %>
           </div>
         </div>
         <div class="mt-5 text-center">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,101 @@
+<main>
+  <div class="container">
+    <div class="jumbotron text-center bg-white mt-5">
+      <h2>お客様情報登録</h2>
+    </div>
+    <div class="row mb-5 ml-5">
+      <div class="col-sm-6 offset-sm-3">
+      <%= form_for (@user) do |form| %>
+        <div>
+          <p>氏名</p>
+          <div class="row ms-2">
+            <%= form.label :last_name, "姓", class: "col-sm" %>
+            <div class="col-sm-5">
+            <%= form.text_field :last_name, class: "form-control", id: "last_name", maxlength: 10 %>
+            </div>
+            <%= form.label :first_name, "名", class: "col-sm" %>
+            <div class="col-sm-5">
+            <%= form.text_field :first_name, class: "form-control", id: "first_name", maxlength: 10 %>
+            </div>
+          </div>
+          <div>
+          <%= form.label :zipcode, "郵便番号" %>
+            <div class="col-sm-6 ms-4">
+            <%= form.text_field :zipcode, class: "form-control", id: "zipcode", title: "半角数字でハイフンを含めて入力してください", pattern: "[0-9]{3}-[0-9]{4}",length: 8 %>
+            </div>
+          </div>
+          <div>
+            <p class="mb-1">住所</p>
+            <div class="ms-4">
+              <div class="row">
+              <%= form.label :prefecture, "都道府県", class: "mt-2 ml-4 col-sm" %>
+                <div class="col-sm-9 mt-1">
+                <%= form.text_field :prefecture, class: "form-control", id: "prefecture", maxlength: 5 %>
+                </div>
+              </div>
+
+              <div class="row">
+              <%= form.label :municipality, "市町村区", class: "ml-4 mt-2 col-sm" %>
+                <div class="col-sm-9 mt-1">
+                <%= form.text_field :municipality, class: "form-control", id: "municipality", maxlength: 10 %>
+                </div>
+              </div>
+              <div class="row">
+              <%= form.label :address, "番地", class: "mt-2 ml-4 mr-2 col-sm" %>
+                <div class="col-sm-9 ml-4 mt-1">
+                <%= form.text_field :address, class: "form-control", id: "address", maxlength: 15 %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+          <%= form.label :apartments, "マンション・部屋番号", class: "ml-2 ms-4" %>
+            <div class="offset-sm-1">
+              <div class="ml-5 mr-5">
+              <%= form.text_field :apartments, class: "form-control", id: "apartments", maxlength: 20 %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+        <%= form.label :company_name, "会社名" %>
+          <div class="ml-3 mr-5 ms-4">
+          <%= form.text_field :company_name, class: "form-control", id: "company_name" %>
+          </div>
+        </div>
+        <%= form.label :email, "メールアドレス" %>
+          <div class="ml-3 mr-5 ms-4">
+          <%= form.email_field :email, class: "form-control", id: "email" %>
+          </div>
+        </div>
+        <div>
+        <%= form.label :phone_number, "電話番号" %>
+          <div class="ml-3 mr-5 ms-4">
+          <%= form.text_field :phone_number, class: "form-control", id: "phone_number", title: "半角数字でハイフンを含めずに入力してください", pattern: "[0-9][0-9]*", maxlength: "15" %>
+          </div>
+        </div>
+        <div>
+        <%= form.label :password, "パスワード" %>
+          <div class="col-sm-8 ms-4">
+          <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
+          </div>
+        </div>
+        <div>
+          <%= form.label :password, "パスワード再入力" %>
+          <div class="col-sm-8 ms-4">
+          <%= form.password_field :password, class: "form-control", id: "password", pattern: "^[0-9A-Za-z]+$", minlength: 6, maxlength: 15 %>
+          </div>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-sm-2 mt-5">
+          <%= form.submit "登録", class: "btn btn-primary btn-block" %>
+          </div>
+        </div>
+        <div class="mt-5 text-center">
+          <h3><%= link_to "ログインはこちらから", login_path %></h3>
+        </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   get '/login' => 'sessions#new'
   post   'login'   => 'sessions#create'
   delete 'logout'  => 'sessions#destroy'
+  get '/signup' => 'users#new'
+  post '/signup' => 'users#create'
   resources :products
   resources :users
 end


### PR DESCRIPTION
## このプルリクエストで何をしたのか

- [ ] ユーザー登録ページの作成

* routesにpath: GET /signupを指定
* コントローラにnew作成
* new.html.erb作成
* html対応のvalidationをzipocodeカラムに追記
* comany_nameのカラム枠を追記
 

- [ ] 登録処理

* routesにpath: POST /signupを指定
* コントローラにcreateを定義
* 登録が成功時、フラッシュメッセージとともにlogin画面にリダイレクト
* 登録が失敗時、エラーメッセージとともにrenderでnewページに返す

- [ ] その他
* sessions/new.html.erbの`<a href="">まだ登録がお済みでない方はこちら</a>`を`link_to`に変更し遷移先を指定。

## 対象issue
- 作業したissueのURLをここに貼ること
https://github.com/quest-academia/qa-rails-ec-training-azalea/issues/41
## 重点的に見てほしいところ(不安なところ)
量が多いので下にまとめて書きました。
## 実装できなくて後回しにしたところ

## チェックリスト
- [ ] 動作確認は実行した?
- [ ] rubocopは実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること

ユーザ登録画面のレイアウトが大幅に崩れているため、edit画面のレイアウトを参考にしてもう一度作り直そうと考えています。納期は明日なので時間はあると考えてます。
その場合、大幅に変更が加えられるので一度確認をいただくために、pushしました。この流れで進めてもよろしいでしょうか？
また、今回新たに登録ページに「会社名」のカラム枠を設けたので、同様にedit画面にも追記する必要があります。（未実装）
![スクリーンショット 2021-05-22 13 55 32](https://user-images.githubusercontent.com/78217764/119214927-63e33f80-bb05-11eb-8ce5-8280c1327afa.png)
